### PR TITLE
Support publishing on linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,8 @@
 #
 .EXPORT_ALL_VARIABLES:
 .ONESHELL:
-.SHELL := /bin/bash
+.SHELL: path=/bin/bash
+SHELL := /usr/bin/bash
 .PHONY: serve publish
 # Default to use pipenv unless disabled
 PIPENV=true

--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,6 @@
 #
 .EXPORT_ALL_VARIABLES:
 .ONESHELL:
-.SHELL: path=/bin/bash
-SHELL := /usr/bin/bash
 .PHONY: serve publish
 # Default to use pipenv unless disabled
 PIPENV=true
@@ -18,7 +16,7 @@ help:
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
 prep:
-	[ "${PIPENV}" == "true" ] && pipenv install
+	[ "${PIPENV}" = "true" ] && pipenv install
 
 serve: prep ## Serve locally the generated pages
 	${PIPENVCMD} mkdocs serve


### PR DESCRIPTION
I needed the SHELL addition to run in Linux, but also changed the path for .SHELL since apparently that's the correct BSD form.

Could you verify `make build` still works for you on OS X please?

This was the original error that I was seeing:

```bash
$ make build
[ "true" == "true" ] && pipenv install
/bin/sh: 1: [: true: unexpected operator
make: *** [Makefile:20: prep] Error 2
```