### PR TITLE
Clarify Paxos repair mechanisms: background vs coordinated

### DIFF
--- a/docs/data-platforms/cassandra/architecture/distributed-data/paxos.md
+++ b/docs/data-platforms/cassandra/architecture/distributed-data/paxos.md
@@ -356,7 +356,52 @@ paxos_variant: v2
 paxos_state_purging: repaired
 ```
 
+!!! note "`paxos_variant` and `paxos_state_purging` Are Independent"
+    These two settings do not depend on each other. You can enable Paxos v2 without changing `paxos_state_purging`, or set `paxos_state_purging: repaired` with Paxos v1. However, the recommended production configuration for LWT-heavy clusters is `v2` + `repaired`, which together enable the [commit consistency optimization](#commit-consistency-optimization) below.
+
 For detailed configuration options, see [Paxos-Related cassandra.yaml Configuration](../../operations/repair/strategies.md#paxos-related-cassandrayaml-configuration).
+
+### Paxos State Purging
+
+The `paxos_state_purging` setting controls how old entries in the `system.paxos` table are cleaned up:
+
+| Value | Mechanism | Safe with Commit CL=ANY | Revert Path |
+|-------|-----------|------------------------|-------------|
+| `legacy` | TTL-based expiration | **No** — committed values may expire before propagation | N/A (default) |
+| `gc_grace` | Compaction-time expiry based on `gc_grace_seconds`, no TTLs | **No** | Safe fallback from `repaired` |
+| `repaired` | Purged only after Paxos repair low bound confirms quorum persistence | **Yes** | **MUST** revert to `gc_grace`, **NOT** `legacy` |
+
+With `repaired`, Cassandra uses the low bound recorded in `system.paxos_repair_history` to determine which `system.paxos` entries can be safely purged during compaction. This low bound is only advanced by **coordinated Paxos repairs** (`nodetool repair --paxos-only` or regular `nodetool repair`), not by the automatic background Paxos repair. See [Understanding the Two Paxos Repair Mechanisms](../../operations/repair/strategies.md#understanding-the-two-paxos-repair-mechanisms) for the full distinction.
+
+### Commit Consistency Optimization
+
+LWT operations in Cassandra use two consistency levels:
+
+- **Serial consistency level** (`SERIAL` or `LOCAL_SERIAL`): Controls the Paxos consensus phase — how many replicas must participate in the prepare/propose/accept rounds.
+- **Commit (non-serial) consistency level**: Controls the final commit phase — how many replicas must acknowledge that the committed value has been written to the base table.
+
+These are configured separately in application code. For example, a query might use `LOCAL_SERIAL` for consensus and `LOCAL_QUORUM` for the commit.
+
+With Paxos v2 and `paxos_state_purging: repaired`, the commit consistency level can be safely set to `ANY`. This eliminates a WAN round-trip because the coordinator does not need to wait for a quorum acknowledgment of the commit — the Paxos repair mechanism guarantees that committed values will eventually be propagated.
+
+**Prerequisites for commit CL=ANY:**
+
+1. `paxos_variant: v2` set consistently across **all nodes**
+2. `paxos_state_purging: repaired` set consistently across **all nodes**
+3. Regular coordinated Paxos repairs running (`nodetool repair --paxos-only` or regular `nodetool repair`)
+
+**Example driver configuration (Java):**
+
+```java
+// Serial consistency controls the Paxos consensus phase
+statement.setSerialConsistencyLevel(ConsistencyLevel.LOCAL_SERIAL);
+
+// Commit consistency controls the final write — can be ANY with v2 + repaired
+statement.setConsistencyLevel(ConsistencyLevel.ANY);
+```
+
+!!! warning "Reverting Commit CL"
+    If `paxos_state_purging` must be changed from `repaired` to `gc_grace` (for example, because coordinated Paxos repairs must be disabled for an extended period), applications **MUST** change their commit consistency level back from `ANY` to `QUORUM` or `LOCAL_QUORUM` to maintain correctness.
 
 ### Upgrade Considerations
 
@@ -376,9 +421,12 @@ For detailed configuration options, see [Paxos-Related cassandra.yaml Configurat
 | **Quorum** | Majority of replicas; with RF=3, quorum is 2 |
 | **Ballot** | Unique proposal number combining timestamp and node ID |
 | **Paxos state** | Entries in `system.paxos` table tracking proposals and accepted values |
-| **Paxos repair** | Process of reconciling Paxos state across replicas |
+| **Background Paxos repair** | Automatic process (every 5 min in 4.1+) that completes uncommitted Paxos transactions. Does not advance the repair low bound. |
+| **Coordinated Paxos repair** | `nodetool repair --paxos-only` or the Paxos step in regular `nodetool repair`. Completes uncommitted transactions AND advances the low bound in `system.paxos_repair_history`, enabling `system.paxos` garbage collection. |
+| **Paxos repair low bound** | Ballot recorded in `system.paxos_repair_history` indicating the point up to which Paxos state has been safely reconciled. Used by `paxos_state_purging: repaired` to determine what can be garbage collected. |
+| **Serial consistency** | Consistency level (`SERIAL` or `LOCAL_SERIAL`) controlling the Paxos consensus phase |
+| **Commit consistency** | Non-serial consistency level controlling the final commit write. Can be set to `ANY` with Paxos v2 + `repaired` purging. |
 | **LWT** | Lightweight Transaction—Cassandra's conditional atomic operations using Paxos |
-| **SERIAL** | Consistency level that uses Paxos for linearizable operations |
 
 ---
 
@@ -401,9 +449,9 @@ For detailed configuration options, see [Paxos-Related cassandra.yaml Configurat
 
 ### Operational Requirements
 
-- **Paxos state accumulates**: Without regular Paxos repairs, `system.paxos` grows unboundedly
+- **Paxos state accumulates**: Without regular **coordinated** Paxos repairs (`nodetool repair --paxos-only` or regular `nodetool repair`), `system.paxos` grows unboundedly when using `paxos_state_purging: repaired`. The automatic background Paxos repair does not advance the low bound needed for garbage collection.
 - **Topology changes**: Paxos repairs **MUST** complete before topology changes (bootstrap, decommission)
-- **Repair requirements**: Clusters using LWTs **MUST** run regular Paxos repairs
+- **Repair requirements**: Clusters using LWTs with `paxos_state_purging: repaired` **MUST** run regular coordinated Paxos repairs
 
 For operational guidance, see [Paxos Repairs](../../operations/repair/strategies.md#paxos-repairs).
 

--- a/docs/data-platforms/cassandra/operations/repair/concepts.md
+++ b/docs/data-platforms/cassandra/operations/repair/concepts.md
@@ -702,7 +702,12 @@ Paxos repairs maintain LWT **linearizability** and correctness, especially acros
 
 Paxos repairs are only relevant for **keyspaces that use LWTs**. For keyspaces that never use LWTs, Paxos state does not affect correctness, and operators **MAY** safely skip Paxos repairs for those keyspaces.
 
-In Cassandra 4.1+, Paxos repairs run automatically every 5 minutes by default. Operators **SHOULD** ensure Paxos repairs run regularly on clusters where LWTs are in use. See [Paxos Repairs](strategies.md#paxos-repairs) in the Repair Strategies guide for operational details.
+Cassandra 4.1+ provides two distinct Paxos repair mechanisms:
+
+1. **Background Paxos repair** — runs automatically every 5 minutes (configurable). Completes uncommitted Paxos transactions but does **NOT** advance the Paxos repair low bound or enable garbage collection of `system.paxos` data.
+2. **Coordinated Paxos repair** — runs via `nodetool repair --paxos-only` or as part of regular `nodetool repair`. Completes uncommitted transactions **AND** advances the low bound in `system.paxos_repair_history`, enabling garbage collection when using `paxos_state_purging: repaired`.
+
+For clusters using `paxos_state_purging: repaired`, operators **MUST** run regular coordinated Paxos repairs. The automatic background repair alone is not sufficient. See [Understanding the Two Paxos Repair Mechanisms](strategies.md#understanding-the-two-paxos-repair-mechanisms) in the Repair Strategies guide for the full distinction.
 
 ### Paxos Repairs and Topology Changes
 
@@ -760,9 +765,11 @@ Cassandra 4.1+ introduces **Paxos v2**, an updated Paxos implementation for ligh
 
 Paxos v2 is selected via the `paxos_variant` setting in `cassandra.yaml` (values: `v1` or `v2`).
 
-To safely take full advantage of Paxos v2, operators **MUST** ensure:
+`paxos_variant` and `paxos_state_purging` are **independent settings** — neither requires the other. However, the recommended production configuration for LWT-heavy clusters is `paxos_variant: v2` combined with `paxos_state_purging: repaired`, which together enable the [commit consistency optimization](../../architecture/distributed-data/paxos.md#commit-consistency-optimization).
 
-1. **Regular Paxos repairs** are running on all nodes
+To safely take full advantage of Paxos v2 with `repaired` purging, operators **MUST** ensure:
+
+1. **Regular coordinated Paxos repairs** are running (via `nodetool repair --paxos-only` schedule or regular `nodetool repair`)
 2. **Paxos state purging** is configured appropriately (see [Paxos-related cassandra.yaml configuration](strategies.md#paxos-related-cassandrayaml-configuration) in the Repair Strategies guide)
 
 Detailed configuration options and upgrade guidance are covered in the [Repair Strategies](strategies.md) documentation.

--- a/docs/data-platforms/cassandra/operations/repair/options-reference.md
+++ b/docs/data-platforms/cassandra/operations/repair/options-reference.md
@@ -642,27 +642,24 @@ nodetool repair --paxos-only my_keyspace
 
 **How it works:**
 
-Paxos repairs synchronize the Paxos commit log entries stored in `system.paxos` across replicas. This ensures that all nodes agree on the outcome of previous LWT operations, which is essential for maintaining linearizability guarantees.
+This command runs a **coordinated Paxos repair** that synchronizes Paxos state stored in `system.paxos` across replicas. Unlike the [automatic background Paxos repair](strategies.md#background-paxos-repair-automatic) (which only completes uncommitted transactions), `--paxos-only` also advances the **Paxos repair low bound** by writing to `system.paxos_repair_history`. This low bound is what enables garbage collection of old `system.paxos` data when using `paxos_state_purging: repaired`.
 
 **When to use:**
 
-- **Pre-4.1 clusters**: Operators **MUST** schedule `--paxos-only` repairs manually (typically hourly) since automatic Paxos repairs are not available
-- **Before topology changes**: Run on all nodes before bootstrap, decommission, replace, or move operations to reduce the risk of Paxos cleanup timeouts
-- **After disabling automatic Paxos repairs**: If `paxos_repair_enabled` is set to `false`, manual Paxos repairs **MUST** be scheduled regularly for clusters using LWTs
-- **Troubleshooting LWT issues**: When LWTs are timing out or behaving unexpectedly
+- **Clusters using `paxos_state_purging: repaired`**: Operators **MUST** run `--paxos-only` repairs regularly (typically hourly) or ensure regular full repairs include the Paxos step. The automatic background repair does **NOT** advance the low bound, so without coordinated repairs, `system.paxos` grows unboundedly.
+- **Pre-4.1 clusters**: Operators **MUST** schedule `--paxos-only` repairs manually since the automatic background repair is not available.
+- **Before topology changes**: Run on all nodes before bootstrap, decommission, replace, or move operations to reduce the risk of Paxos cleanup timeouts.
+- **After disabling automatic Paxos repairs**: If `paxos_repair_enabled` is set to `false`, coordinated Paxos repairs **SHOULD** be scheduled regularly for clusters using LWTs.
+- **Troubleshooting LWT issues**: When LWTs are timing out or behaving unexpectedly.
 
-**Automatic Paxos repairs (Cassandra 4.1+):**
+**Relationship to automatic background Paxos repair (Cassandra 4.1+):**
 
-In Cassandra 4.1 and later, Paxos repairs run automatically every 5 minutes by default when `paxos_repair_enabled` is `true`. Manual `--paxos-only` repairs are typically only needed for:
-
-- Pre-4.1 clusters
-- Clusters where automatic Paxos repairs have been disabled
-- Proactive cleanup before topology changes
+Cassandra 4.1+ includes an automatic background Paxos repair that runs every 5 minutes (controlled by `paxos_repair_enabled`). This background repair completes uncommitted transactions but does **NOT** replace the need for coordinated `--paxos-only` repairs. See [Understanding the Two Paxos Repair Mechanisms](strategies.md#understanding-the-two-paxos-repair-mechanisms) for the full distinction.
 
 **Operational guidance:**
 
 - Running without a keyspace argument repairs Paxos state for **all keyspaces**. This is often **RECOMMENDED** because operators frequently do not know which keyspaces developers are using for LWTs.
-- Paxos repairs are lightweight compared to full data repairs and complete quickly
+- Paxos repairs are lightweight compared to full data repairs and complete quickly.
 
 For more details on Paxos repair strategy and configuration, see [Paxos Repairs](strategies.md#paxos-repairs) in the Repair Strategies guide.
 

--- a/docs/data-platforms/cassandra/operations/repair/strategies.md
+++ b/docs/data-platforms/cassandra/operations/repair/strategies.md
@@ -634,18 +634,61 @@ Paxos repairs reconcile the Paxos state used by [lightweight transactions (LWTs)
 
 For conceptual background on Paxos repairs, see [Paxos Repairs](concepts.md#paxos-repairs) in the Repair Concepts guide.
 
-### Regular Paxos-Only Repairs
+### Understanding the Two Paxos Repair Mechanisms
 
-For clusters using LWTs, operators **SHOULD** run **Paxos-only repairs** regularly. This can be accomplished via:
+Cassandra 4.1+ has **two distinct Paxos repair mechanisms** that serve different purposes. Understanding the difference is critical for correct operational configuration.
 
-- **Automatically every 5 minutes** (Cassandra 4.1+) when Paxos repairs are not disabled
-- **Scheduled `nodetool repair --paxos-only`** runs
+#### Background Paxos Repair (Automatic)
 
-In Cassandra 4.1 and later, Paxos repairs run automatically every **5 minutes by default** as part of the cluster's background maintenance (similar to compaction). This requires no manual configuration when `paxos_repair_enabled` is `true` (the default).
+The **background Paxos repair** runs automatically on every node at a configurable interval (default: every 5 minutes). It is controlled by the `paxos_repair_enabled` setting.
 
-> **Important:** The `paxos_repair_enabled` setting only controls automatic Paxos repairs. It does **NOT** affect manual `nodetool repair --paxos-only` operations. If you disable automatic Paxos repairs and are using LWTs, you **MUST** implement a manual schedule.
+**What it does:**
 
-For Cassandra versions prior to 4.1, operators **MUST** schedule `nodetool repair --paxos-only` manually via cron or external scheduling tools, typically running at least hourly:
+- Scans for Paxos transactions that were started (prepare/propose phase) but never committed
+- Completes these stalled transactions by coordinating with a majority of replicas
+- Keeps the backlog of uncommitted Paxos state to a minimum
+
+**What it does NOT do:**
+
+- Does **NOT** advance the Paxos repair low bound
+- Does **NOT** write to `system.paxos_repair_history`
+- Does **NOT** enable garbage collection of old `system.paxos` data
+
+The background repair is housekeeping. It keeps uncommitted transaction volume low, which makes coordinated repairs faster, but it is not sufficient on its own for clusters using `paxos_state_purging: repaired`.
+
+#### Coordinated Paxos Repair (Manual or Scheduled)
+
+The **coordinated Paxos repair** runs when operators execute `nodetool repair --paxos-only`, or as part of a regular `nodetool repair` (unless `--skip-paxos` is specified).
+
+**What it does (in addition to completing uncommitted transactions):**
+
+- Advances the **Paxos repair low bound** by writing to `system.paxos_repair_history`
+- Enables garbage collection of old `system.paxos` data when using `paxos_state_purging: repaired`
+- Synchronizes Paxos repair history across replicas
+
+The low bound recorded in `system.paxos_repair_history` tells Cassandra: "all Paxos state older than this ballot has been safely persisted to a quorum of replicas." With `paxos_state_purging: repaired`, Cassandra uses this low bound to determine which `system.paxos` entries can be safely purged during compaction.
+
+#### Summary: Background vs Coordinated Repair
+
+| Capability | Background (automatic) | Coordinated (`nodetool`) |
+|---|---|---|
+| Completes uncommitted transactions | Yes | Yes |
+| Advances low bound | **No** | **Yes** |
+| Writes to `system.paxos_repair_history` | **No** | **Yes** |
+| Enables `system.paxos` garbage collection | **No** | **Yes** |
+| Required for `paxos_state_purging: repaired` | No (but helpful) | **Yes** |
+| Runs automatically | Yes (every 5 min) | No (must be scheduled) |
+
+!!! warning "Both Mechanisms Are Needed with `paxos_state_purging: repaired`"
+    If your cluster uses `paxos_state_purging: repaired` (the recommended setting for Paxos v2), you **MUST** run regular coordinated Paxos repairs — either `nodetool repair --paxos-only` on a schedule, or regular full repairs that include the Paxos step. The automatic background repair alone is **NOT** sufficient. Without coordinated repairs, the low bound never advances, `system.paxos` data is never purged, and the table grows unboundedly.
+
+### Running Coordinated Paxos Repairs
+
+For clusters using `paxos_state_purging: repaired`, operators **MUST** ensure coordinated Paxos repairs run regularly. This can be accomplished via:
+
+- **Regular `nodetool repair`** (which includes a Paxos repair step by default)
+- **Scheduled `nodetool repair --paxos-only`** runs (typically hourly)
+- **AxonOps scheduled Paxos-only repairs**
 
 ```bash
 # Run Paxos-only repair on all keyspaces (recommended when unsure which keyspaces use LWTs)
@@ -657,7 +700,11 @@ nodetool repair --paxos-only my_lwt_keyspace
 
 Running without a keyspace argument repairs Paxos state for all keyspaces. This is often **RECOMMENDED** because operators frequently do not know which keyspaces developers are using for LWTs.
 
-Paxos repairs are relatively lightweight compared to full data repairs. On clusters running Cassandra 4.1+, the automatic 5-minute interval keeps Paxos state compact and consistent without operator intervention.
+For Cassandra versions prior to 4.1, there is no automatic background repair, so operators **MUST** schedule `nodetool repair --paxos-only` manually via cron or external scheduling tools.
+
+Paxos repairs are relatively lightweight compared to full data repairs.
+
+> **Important:** The `paxos_repair_enabled` setting controls the automatic background Paxos repair. It does **NOT** affect manual `nodetool repair --paxos-only` operations. If you disable automatic Paxos repairs and are using LWTs, you **SHOULD** still run scheduled coordinated repairs.
 
 Disabling Paxos repairs for extended periods **MAY** lead to stale or inconsistent LWT state, especially around topology changes. If Paxos state grows large, topology operations such as bootstrap **MAY** fail due to Paxos cleanup timeouts.
 
@@ -743,23 +790,23 @@ paxos_variant: v2
 
 #### paxos_state_purging
 
-Controls how old Paxos state is purged from the system tables.
+Controls how old Paxos state is purged from the `system.paxos` table. This setting is **independent** of `paxos_variant` — they do not depend on each other — but the recommended production configuration is `paxos_variant: v2` combined with `paxos_state_purging: repaired`.
 
 | Value | Description |
 |-------|-------------|
-| `legacy` | Original behavior; Paxos state retained until explicit cleanup |
-| `gc_grace` | Purge Paxos state based on `gc_grace_seconds` of the table |
-| `repaired` | Purge Paxos state only after it has been repaired (requires regular Paxos repairs) |
+| `legacy` | Paxos state is written with TTLs and garbage collected via normal TTL expiration. This is **unsafe** with commit consistency `ANY` because a committed value that has not yet been read-repaired to all replicas could expire before being propagated. |
+| `gc_grace` | Paxos state is expired at compaction and read time based on `gc_grace_seconds`, without using TTLs. This is the **safe fallback** if reverting from `repaired`. |
+| `repaired` | Paxos state is purged only after the Paxos repair low bound confirms the data is safely persisted to a quorum. **Requires regular coordinated Paxos repairs** (`nodetool repair --paxos-only` or regular `nodetool repair`) to advance the low bound. Enables the commit consistency `ANY` optimization. |
 
 **Operational guidance:**
 
-- For Paxos v2, `paxos_state_purging: repaired` is typically **RECOMMENDED**, but **only** when Paxos repairs run regularly or automatically
-- Once `repaired` is enabled, operators generally **MUST NOT** switch back to `legacy` without careful consideration
-- If purging needs to be relaxed, switching to `gc_grace` **MAY** be appropriate but requires more conservative consistency levels
-- This setting **SHOULD** be changed consistently across all nodes in the cluster
+- For Paxos v2, `paxos_state_purging: repaired` is **RECOMMENDED**, but **only** when **coordinated** Paxos repairs (via `nodetool repair --paxos-only` or regular `nodetool repair`) run regularly. The automatic background Paxos repair alone is **NOT** sufficient — it does not advance the low bound needed for purging.
+- Once `repaired` is set, operators **MUST NOT** revert to `legacy`. If purging needs to be relaxed, operators **MUST** use `gc_grace` instead. Reverting to `legacy` can cause data loss because `legacy` uses TTLs that may expire state before it has been propagated.
+- If reverting from `repaired` to `gc_grace`, applications **MUST** also change their commit (non-serial) consistency level back from `ANY` to `QUORUM` or `LOCAL_QUORUM`.
+- This setting **SHOULD** be changed consistently across all nodes in the cluster.
 
 ```yaml
-# cassandra.yaml - recommended for Paxos v2 with regular repairs
+# cassandra.yaml - recommended for Paxos v2 with regular coordinated repairs
 paxos_state_purging: repaired
 ```
 
@@ -774,11 +821,10 @@ Global enable/disable switch for automatic Paxos repairs.
 
 **Operational guidance:**
 
-- When enabled (default), Paxos repairs run automatically on a **5-minute interval** in Cassandra 4.1+, and also run automatically before topology changes (bootstrap, decommission, replace, move).
-- When `false`, automatic Paxos repairs are disabled. However, **manual** Paxos repairs via `nodetool repair --paxos-only` continue to work and **MUST** be scheduled regularly if the cluster uses LWTs.
-- For clusters using LWTs, this setting **SHOULD** remain `true` under normal circumstances.
-- If automatic Paxos repairs are disabled (`false`), operators **MUST** schedule `nodetool repair --paxos-only` via cron or external automation (typically hourly) to maintain LWT correctness.
-- Disabling automatic Paxos repairs without a manual replacement schedule **MAY** lead to stale or inconsistent LWT state.
+- When enabled (default), the [background Paxos repair](#background-paxos-repair-automatic) runs automatically on a **5-minute interval** in Cassandra 4.1+, and also runs automatically before topology changes (bootstrap, decommission, replace, move).
+- When `false`, the automatic background repair is disabled. However, **manual** [coordinated Paxos repairs](#coordinated-paxos-repair-manual-or-scheduled) via `nodetool repair --paxos-only` continue to work.
+- For clusters using LWTs, this setting **SHOULD** remain `true` under normal circumstances. The background repair reduces uncommitted transaction backlog, which makes coordinated repairs faster.
+- Even when `true`, this setting does **NOT** eliminate the need for regular coordinated Paxos repairs when using `paxos_state_purging: repaired`. The background repair does not advance the low bound needed for `system.paxos` garbage collection.
 - Only consider setting this to `false` if you have completely removed LWT usage from your application and have validated that no keyspaces rely on LWTs.
 
 ```yaml
@@ -858,9 +904,22 @@ Both formats are equivalent.
 |---------|---------|--------------|------------------|
 | `paxos_variant` | `v1` (< 4.1), `v2` (4.1+) | `v2` **RECOMMENDED** | Either |
 | `paxos_state_purging` | `legacy` | `repaired` **RECOMMENDED** | `legacy` or `gc_grace` |
-| `paxos_repair_enabled` | `true` | **MUST** be `true` | **MAY** be `false` |
+| `paxos_repair_enabled` | `true` | **SHOULD** be `true` | **MAY** be `false` |
 | `skip_paxos_repair_on_topology_change` | `false` | **SHOULD** be `false` | **MAY** be `true` |
 | `skip_paxos_repair_on_topology_change_keyspaces` | (empty) | Non-LWT keyspaces only | Any |
+
+### Recommended Configuration Path for LWT Clusters
+
+The following steps can be performed independently, but this is the recommended order for clusters adopting Paxos v2 and optimized purging. Each step has its own prerequisites.
+
+| Step | Configuration | Prerequisite |
+|------|--------------|--------------|
+| 1 | `paxos_variant: v2` | All nodes running Cassandra 4.1+, set consistently across all nodes |
+| 2 | `paxos_state_purging: repaired` | Regular coordinated Paxos repairs running (via `nodetool repair --paxos-only` schedule or regular `nodetool repair`). Monitor `system.paxos` table size to verify purging is working. |
+| 3 | Set commit (non-serial) consistency to `ANY` in application | Steps 1 and 2 both in place cluster-wide. See [Commit Consistency Optimization](../../architecture/distributed-data/paxos.md#commit-consistency-optimization). |
+
+!!! note "`paxos_variant` and `paxos_state_purging` Are Independent"
+    These two settings do not depend on each other. You can use `paxos_variant: v2` with `paxos_state_purging: legacy`, or `paxos_variant: v1` with `paxos_state_purging: repaired`. However, the recommended production configuration is `v2` + `repaired` for best performance and efficient state management.
 
 ---
 


### PR DESCRIPTION
## Summary

- **Distinguishes the two Paxos repair mechanisms** that Cassandra 4.1+ provides: automatic background repair (completes uncommitted transactions only) vs coordinated repair via `nodetool` (also advances the low bound and enables `system.paxos` garbage collection)
- **Fixes incorrect guidance** that `--paxos-only` repairs are only needed for pre-4.1 clusters — they are required when using `paxos_state_purging: repaired`
- **Adds Commit Consistency Optimization section** explaining serial CL vs commit CL and the `ANY` optimization with Paxos v2 + `repaired`
- **Expands `paxos_state_purging` descriptions** with actual mechanisms (TTL-based, compaction-time, low-bound), revert paths, and safety notes
- **Adds config independence callout** — `paxos_variant` and `paxos_state_purging` are independent settings
- **Adds recommended configuration path** for LWT clusters adopting Paxos v2

### Context

This was prompted by confusion in the Apache Cassandra Slack where an operator couldn't tell whether their scheduled `nodetool repair --paxos-only` was redundant given Cassandra's automatic repairs. Our docs presented the two as interchangeable alternatives, when they actually serve different purposes.

## Files Changed

- `docs/data-platforms/cassandra/operations/repair/strategies.md` — Major rewrite of Paxos Repairs section
- `docs/data-platforms/cassandra/operations/repair/options-reference.md` — Fix `--paxos-only` guidance
- `docs/data-platforms/cassandra/operations/repair/concepts.md` — Clarify two-mechanism distinction
- `docs/data-platforms/cassandra/architecture/distributed-data/paxos.md` — Add purging, commit CL, terminology

## Test plan

- [ ] Verify mkdocs builds without errors
- [ ] Check all internal anchor links resolve (new sections use anchors referenced from other pages)
- [ ] Review Paxos Repairs section in strategies.md for technical accuracy
- [ ] Review Commit Consistency Optimization section in paxos.md for driver examples
- [ ] Confirm the comparison table (background vs coordinated) is accurate per Cassandra source